### PR TITLE
Python310 web3 6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ setuptools==50.3.2
 six==1.14
 sympy==1.6
 tox==3.25.0
-web3>=5.25.0,<6.0.0
+web3>=5.25.0
 importlib-metadata>=1.6.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ REQUIREMENTS = [
     'setuptools>=50.3.2',
     'sympy>=1.6',
     'tox>=3.13.2',
-    'web3>=5.0.0,<6.0.0',
+    'web3>=5.0.0',
 ]
 
 setup(


### PR DESCRIPTION
![Screenshot 2022-06-29 at 14 22 55](https://user-images.githubusercontent.com/46008456/176449966-ad0fdb21-c520-4c27-8d24-3851cbae6d19.png)

the whl was built, pip installed from that to a virtualenv and imported Client, so increasing that requirement hasn't immediately broken anything that I can see